### PR TITLE
AUTO-308 -- add CI to feature repos

### DIFF
--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -74,8 +74,12 @@ jobs:
       - name: Calculate tags
         id: tag-calculator
         run: |
-          REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}          
-          BUILD_TAG=$REPO:build-${{ github.run_number }}-${{ inputs.triggeringRepo }}-${{ inputs.featureName }}
+          REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}  
+          BRANCH=${{ inputs.featureName }}
+          BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
+
+          BUILD_TAG=$REPO:build-${{ github.run_number }}-${{ inputs.triggeringRepo }}-${BRANCH}
+
           echo "::set-output name=tags::$BUILD_TAG"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -23,6 +23,25 @@ on:
         type: string
         default: '["self-hosted", "X64"]'
         description: A JSON payload describing the runner to use
+      # below variables need setting if a feature repo wants to run the CI
+      # and checkout one ore more feature branches
+      featureName:
+        required: true
+        type: string
+        default: '' # for build on default branch + default *.repos
+        description: This branch is the one that needs to be checked out,
+          and that helps iterating through `src` to checkout related branches
+      integrationRepo:
+        required: true
+        type: string
+        default: ''
+        description: The repository that should be checked out to run the CI          
+      triggeringRepo:
+        required: true
+        type: string
+        default: ''
+        description: The repository that triggered the workflow to better tag the image
+
 
 jobs:
   build:
@@ -35,6 +54,8 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@v2
         with:
+          repository: ${{ inputs.integrationRepo }}
+          ref: ${{ inputs.featureName }}
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 
@@ -53,16 +74,9 @@ jobs:
       - name: Calculate tags
         id: tag-calculator
         run: |
-          REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
-          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
-
-          BUILD_TAG=$REPO:build-${{ github.run_number }}
-          BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
-          BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
-          BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
-
-          echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
+          REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}          
+          BUILD_TAG=$REPO:build-${{ github.run_number }}-${{ inputs.triggeringRepo }}-${{ inputs.featureName }}
+          echo "::set-output name=tags::$BUILD_TAG"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -79,14 +93,15 @@ jobs:
           build-args: |
             GIT_CHECKOUT_PAT=${{ secrets.GIT_CHECKOUT_PAT }}
             BUILD_NUMBER=${{ github.run_number }}
+            FEATURE_NAME=${{ inputs.featureName }}
           tags: ${{ steps.tag-calculator.outputs.tags }}
-          # cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache
+          # cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache	
           # cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache,mode=max
-
+          
       - uses: act10ns/slack@v1
         if: always()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status:  ${{ job.status }}
-          channel: '#notifications'
+          channel: '#autonomy-notifications'

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -23,6 +23,20 @@ on:
         type: string
         default: '["self-hosted", "X64"]'
         description: A JSON payload describing the runner to use
+      # below variables need setting if a feature repo wants to run the CI
+      # and checkout one ore more feature branches
+      is_feature:
+        required: true
+        type: boolean
+        default: false
+        description: A bool whether this action works on a feature repository
+      feature_branch:
+        required: true
+        type: string
+        default: 'something'
+        description: This branch is the one that needs to be checked out,
+          and that helps iterating through `src` to checkout related branches
+
 
 jobs:
   build:
@@ -35,6 +49,8 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@v2
         with:
+          repository: botsandus/auto # should make it work on auto and any feature repo TODO(marcus): maybe make variable to decide on integration repo (could differ between projects)
+          # ref: refs/heads/release # TODO(marcus): pipe in the branch
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 
@@ -53,16 +69,18 @@ jobs:
       - name: Calculate tags
         id: tag-calculator
         run: |
-          REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
-          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
+      # TODO(marcus): temp deactivate tagging while developing 
+      #    REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
+      #    BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+      #    BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
 
-          BUILD_TAG=$REPO:build-${{ github.run_number }}
-          BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
-          BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
-          BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
+      #    BUILD_TAG=$REPO:build-${{ github.run_number }}
+      #    BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
+      #    BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
+      #    BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
 
-          echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
+      #    echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
+           echo "::set-output name=tags::tmp-feature-branch"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -79,14 +97,14 @@ jobs:
           build-args: |
             GIT_CHECKOUT_PAT=${{ secrets.GIT_CHECKOUT_PAT }}
             BUILD_NUMBER=${{ github.run_number }}
+            IS_FEATURE=${{ inputs.is_feature }}
+            FEATURE_BRANCH=${{ inputs.feature_branch }}
           tags: ${{ steps.tag-calculator.outputs.tags }}
-          # cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache
-          # cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache,mode=max
 
-      - uses: act10ns/slack@v1
-        if: always()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status:  ${{ job.status }}
-          channel: '#notifications'
+      #- uses: act10ns/slack@v1
+      #  if: always()
+      #  env:
+      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #  with:
+      #    status:  ${{ job.status }}
+      #    channel: '#notifications'

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -79,8 +79,8 @@ jobs:
           BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
           
           if [[ -z ${{ inputs.featureName }} ]]; then
-            TRIGGERINGREPO=${${{ inputs.triggeringRepo }}//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
-            BUILD_TAG=$REPO:build-${{ github.run_number }}-${TRIGGERINGREPO}-${BRANCH}
+            FEATUREBRANCH=${${{ inputs.featureName }}//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
+            BUILD_TAG=$REPO:build-${{ github.run_number }}-${{ inputs.triggeringRepo }}-${FEATUREBRANCH}
             echo "::set-output name=tags::$BUILD_TAG"
           else
             BUILD_TAG=$REPO:build-${{ github.run_number }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -107,7 +107,9 @@ jobs:
             BUILD_NUMBER=${{ github.run_number }}
             FEATURE_NAME=${{ inputs.featureName }}
           tags: ${{ steps.tag-calculator.outputs.tags }}
-
+          # cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache	
+          # cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache,mode=max
+          
       #- uses: act10ns/slack@v1
       #  if: always()
       #  env:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -110,10 +110,10 @@ jobs:
           # cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache	
           # cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache,mode=max
           
-      #- uses: act10ns/slack@v1
-      #  if: always()
-      #  env:
-      #    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #  with:
-      #    status:  ${{ job.status }}
-      #    channel: '#notifications'
+      - uses: act10ns/slack@v1
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status:  ${{ job.status }}
+          channel: '#notifications'

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -33,7 +33,7 @@ on:
       feature_branch:
         required: true
         type: string
-        default: 'something'
+        default: ''
         description: This branch is the one that needs to be checked out,
           and that helps iterating through `src` to checkout related branches
 
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: botsandus/auto # should make it work on auto and any feature repo TODO(marcus): maybe make variable to decide on integration repo (could differ between projects)
-          # ref: refs/heads/release # TODO(marcus): pipe in the branch
+          ref: ${{ inputs.feature_branch }}  # TODO(marcus): this one should pass the feature branch or should be empty (if running on auto) 
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 
@@ -69,18 +69,17 @@ jobs:
       - name: Calculate tags
         id: tag-calculator
         run: |
+          echo "::set-output name=tags::tmp-feature-branch"        
       # TODO(marcus): temp deactivate tagging while developing 
-      #    REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
-      #    BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-      #    BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
+      #   REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
+      #   BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+      #   BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
 
-      #    BUILD_TAG=$REPO:build-${{ github.run_number }}
-      #    BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
-      #    BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
-      #    BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
-
-      #    echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
-           echo "::set-output name=tags::tmp-feature-branch"
+      #   BUILD_TAG=$REPO:build-${{ github.run_number }}
+      #   BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
+      #   BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
+      #   BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
+      #   echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -31,6 +31,11 @@ on:
         default: '' # for build on default branch + default *.repos
         description: This branch is the one that needs to be checked out,
           and that helps iterating through `src` to checkout related branches
+      integrationRepo:
+        required: false
+        type: string
+        default: ''
+        description: The repository that should be checked out to run the CI          
       triggeringRepo:
         required: false
         type: string
@@ -49,9 +54,7 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@v2
         with:
-          # should make it work on auto and any feature repo TODO(marcus): maybe make variable to decide on integration repo (could differ between projects)
-          repository: botsandus/auto
-          # TODO(marcus): this one should pass the feature branch or should be empty (if running on auto)
+          repository: ${{ inputs.integrationRepo }}
           ref: ${{ inputs.featureName }}
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -25,17 +25,17 @@ on:
         description: A JSON payload describing the runner to use
       # below variables need setting if a feature repo wants to run the CI
       # and checkout one ore more feature branches
-      is_feature:
-        required: true
-        type: boolean
-        default: false
-        description: A bool whether this action works on a feature repository
-      feature_branch:
-        required: true
+      featureName:
+        required: false
         type: string
-        default: ''
+        default: '' # for build on default branch + default *.repos
         description: This branch is the one that needs to be checked out,
           and that helps iterating through `src` to checkout related branches
+      triggeringRepo:
+        required: false
+        type: string
+        default: ''
+        description: The repository that triggered the workflow to better tag the image
 
 
 jobs:
@@ -49,8 +49,10 @@ jobs:
       - name: Checkout with submodules
         uses: actions/checkout@v2
         with:
-          repository: botsandus/auto # should make it work on auto and any feature repo TODO(marcus): maybe make variable to decide on integration repo (could differ between projects)
-          ref: ${{ inputs.feature_branch }}  # TODO(marcus): this one should pass the feature branch or should be empty (if running on auto) 
+          # should make it work on auto and any feature repo TODO(marcus): maybe make variable to decide on integration repo (could differ between projects)
+          repository: botsandus/auto
+          # TODO(marcus): this one should pass the feature branch or should be empty (if running on auto)
+          ref: ${{ inputs.featureName }}
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 
@@ -69,17 +71,21 @@ jobs:
       - name: Calculate tags
         id: tag-calculator
         run: |
-          echo "::set-output name=tags::tmp-feature-branch"        
-      # TODO(marcus): temp deactivate tagging while developing 
-      #   REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
-      #   BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-      #   BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
-
-      #   BUILD_TAG=$REPO:build-${{ github.run_number }}
-      #   BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
-      #   BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
-      #   BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
-      #   echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
+          REPO=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}
+          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          BRANCH=${BRANCH//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
+          
+          if [[ -z ${{ inputs.featureName }} ]]; then
+            TRIGGERINGREPO=${${{ inputs.triggeringRepo }}//[^a-zA-Z0-9\-]/\-} # Strip any invalid characters
+            BUILD_TAG=$REPO:build-${{ github.run_number }}-${TRIGGERINGREPO}-${BRANCH}
+            echo "::set-output name=tags::$BUILD_TAG"
+          else
+            BUILD_TAG=$REPO:build-${{ github.run_number }}
+            BUILD_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${BRANCH}
+            BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
+            BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
+            echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -96,8 +102,7 @@ jobs:
           build-args: |
             GIT_CHECKOUT_PAT=${{ secrets.GIT_CHECKOUT_PAT }}
             BUILD_NUMBER=${{ github.run_number }}
-            IS_FEATURE=${{ inputs.is_feature }}
-            FEATURE_BRANCH=${{ inputs.feature_branch }}
+            FEATURE_NAME=${{ inputs.featureName }}
           tags: ${{ steps.tag-calculator.outputs.tags }}
 
       #- uses: act10ns/slack@v1


### PR DESCRIPTION
This PR does the following:

1. if `featureName` is set, at least one repository has a feature branch `featureName` that the `tirggeringRepo` using the `container-build.yml` workflow wants to test against an `integrationRepo`. For example: we want to implement `AUTO-308_add_CI_to_feature_repos`. This feature name gets assigned to `featureName` automatically (see [here](https://github.com/botsandus/auto-robot/pull/41/files)). The workflow later uses a [Dockerfile](https://github.com/botsandus/auto/blob/2d8dca6f1307251fb7d158dd3bd7c00b3434e5bf/.balena/Dockerfile#L30) that picks the `featureName` and check out all branches with the same name in our workspace (see [action](https://github.com/botsandus/auto-robot/actions/runs/3559158788/jobs/5978330931#step:8:340)). 
2. if `featureName` is not set, the workflow should behave the same as before

Related PR: 

- https://github.com/botsandus/auto/pull/22 : changes to the Dockerfile that allows checking out all branches that are named `featureName` in order to build a full feature across repositories before merging
- https://github.com/botsandus/auto-robot/pull/41: an example workflow within a feature repo that sets the parameter to trigger a CI run in the same repo