### PR TITLE
AUTO-308 -- checkout master on the integration repo as default

### DIFF
--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -55,7 +55,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ inputs.integrationRepo }}
-          ref: ${{ inputs.featureName }}
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 


### PR DESCRIPTION
After https://github.com/botsandus/auto/pull/22 is merged, we want to point to master of the integration repo (currently there need to be a `featureName` branch on `auto`, see [run](https://github.com/botsandus/auto-robot/actions/runs/3568203341/jobs/5996809106#step:8:361)). This was however only for testing.