### PR TITLE
AUTO-308 -- fix flag

### DIFF
--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
     inputs:
       ecrRepo:
-        required: true
+        required: false
         type: string
         default: 'botsandus/arri/auto'
         description: The path of the ECR repository to use


### PR DESCRIPTION
Sorry, when merging earlier I brought back the required flag for `ecrRepo`. This has to be false in order for `auto-robot` to pass without providing inputs: https://github.com/botsandus/auto-robot/actions/runs/3568538682