### PR TITLE
AUTO-310 -- only run tests of feature repo

### DIFF
--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -56,6 +56,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ inputs.integrationRepo }}
+          # TODO(marcus): temporal change, revert before auto#23 gets merged
+          ref: 'AUTO-310_only_run_tests_of_feature_repo'
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 

--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -56,8 +56,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ inputs.integrationRepo }}
-          # TODO(marcus): temporal change, revert before auto#23 gets merged
-          ref: 'AUTO-310_only_run_tests_of_feature_repo'
           submodules: recursive
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
 

--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -98,6 +98,7 @@ jobs:
             GIT_CHECKOUT_PAT=${{ secrets.GIT_CHECKOUT_PAT }}
             BUILD_NUMBER=${{ github.run_number }}
             FEATURE_NAME=${{ inputs.featureName }}
+            TRIGGERING_REPO=${{ inputs.triggeringRepo }}
           tags: ${{ steps.tag-calculator.outputs.tags }}
           # cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache	
           # cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecrRepo }}:github-action-build-cache,mode=max


### PR DESCRIPTION
This PR passes the triggering repo (feature repo) to the Dockerfile so that tests can be executed only on the repo subset (see https://github.com/botsandus/auto/pull/23)

This needs to go in after https://github.com/botsandus/auto/pull/23 but before https://github.com/botsandus/auto-robot/pull/43