### PR TITLE
Change deprecated command

### DIFF
--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -80,7 +80,7 @@ jobs:
 
           BUILD_TAG=$REPO:build-${{ github.run_number }}-${{ inputs.triggeringRepo }}-${BRANCH}
 
-          echo "::set-output name=tags::$BUILD_TAG"
+          echo "{tags}={$BUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -62,7 +62,7 @@ jobs:
           BUILD_COMMIT_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}
           BUILD_COMMIT_BRANCH_TAG=$REPO:build-${{ github.run_number }}-${GITHUB_SHA}-${BRANCH}
 
-          echo "::set-output name=tags::$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG"
+          echo "{tags}={$BUILD_TAG,$BUILD_BRANCH_TAG,$BUILD_COMMIT_TAG,$BUILD_COMMIT_BRANCH_TAG}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Change deprecating save-state and set-output commands of GitHub Actions (see [here](https://github.com/botsandus/auto-docker-images/actions/runs/3714840197/jobs/6299299528#step:3:9)). Changed accordingly to the [GitHub blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)