### PR TITLE
Auto 2005 add pre commit hook to system tests

### DIFF
--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -44,7 +44,7 @@ on:
         description: The repository that triggered the workflow to better tag the image
 
 jobs:
-  pre-commit:
+  style:
     runs-on: ubuntu-latest
     container:
       image: ros:iron-ros-base
@@ -62,7 +62,7 @@ jobs:
 
   start-runner:
     name: Start build runner on EC2
-    needs: pre-commit
+    needs: style
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-runner.outputs.label }}

--- a/.github/workflows/container-build-feature-repo.yml
+++ b/.github/workflows/container-build-feature-repo.yml
@@ -44,7 +44,7 @@ on:
         description: The repository that triggered the workflow to better tag the image
 
 jobs:
-  style:
+  pre-commit:
     runs-on: ubuntu-latest
     container:
       image: ros:iron-ros-base
@@ -62,7 +62,7 @@ jobs:
 
   start-runner:
     name: Start build runner on EC2
-    needs: style
+    needs: pre-commit
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-runner.outputs.label }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -25,7 +25,21 @@ on:
         description: A JSON payload describing the runner to use
 
 jobs:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with: { python-version: "3.10" }
+      - uses: andstor/file-existence-action@v2
+        id: pre_commit_config
+        with:
+          files: "./.pre-commit-config.yaml"
+      - if: steps.pre_commit_config.outputs.files_exists == 'true'
+        uses: pre-commit/action@v3.0.0
+
   build:
+    needs: style
     runs-on: ${{ fromJSON(inputs.runner) }}
 
     concurrency:

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -25,7 +25,7 @@ on:
         description: A JSON payload describing the runner to use
 
 jobs:
-  style:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
         uses: pre-commit/action@v3.0.0
 
   build:
-    needs: style
+    needs: pre-commit
     runs-on: ${{ fromJSON(inputs.runner) }}
 
     concurrency:


### PR DESCRIPTION
JIRA: https://dexory.atlassian.net/browse/AUTO-2005

Since this `pre-commit` action is only for usage (for now) on non-ROS builds, then I added a pure `pre-commit` hook that will check for the style only if a `.pre-commit-config.yaml` file exists in the current repository

NOTE: This is the standard way of using `pre-commit` in the CI. For the https://github.com/botsandus/github-actions/pull/9 case, I did it differently since I'm relying on https://github.com/botsandus/ament_lint_pre_commit that assumes to have `ament_*` tools installed on the system ( * )

( * ) Other option would be to install it on each job run (super slow)
( ** ) Other 2nd option would be to use pure Python packages, which we could, I did for [some packages](https://pypi.org/search/?q=ament), but besides being non ROSy enough, we would need to maintain a lot of linters in Pypi