### PR TITLE
Enables git LFS when checking out from git

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -56,6 +56,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.GIT_CHECKOUT_PAT }}
+          lfs: true
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
This is for: https://dexory.atlassian.net/browse/PT-505

As part of the block-stack projects we have a number of .pcd files for testing, these should be stored using git-lfs rather than directly in the repo. This works fine, except for when running the ci containers, this is because by default the github checkout action has lfs as disabled, this PR just enables it