### PR TITLE
TECH 149 SSH ECR credentials

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -56,18 +56,6 @@ jobs:
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
     steps:
-      - name: Tailscale SSH debug (${{
-          inputs.ssh-debug
-            && (runner.debug && 'enabled' || 're-run with debug logging to enable')
-            || 'disabled'
-          }})
-
-        if: ${{ inputs.ssh-debug && runner.debug }}
-        uses: botsandus/github-actions/tailscale-ssh@master
-        with:
-          ssh-wait-minutes: ${{ inputs.ssh-wait-minutes }}
-          ts-authkey: ${{ secrets.TAILSCALE_CI_BUILDER_KEY }}
-
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v1
 
@@ -112,6 +100,18 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Tailscale SSH debug (${{
+          inputs.ssh-debug
+            && (runner.debug && 'enabled' || 're-run with debug logging to enable')
+            || 'disabled'
+          }})
+
+        if: ${{ inputs.ssh-debug && runner.debug }}
+        uses: botsandus/github-actions/tailscale-ssh@master
+        with:
+          ssh-wait-minutes: ${{ inputs.ssh-wait-minutes }}
+          ts-authkey: ${{ secrets.TAILSCALE_CI_BUILDER_KEY }}
 
       - name: Build and push the container
         id: build

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ job screen and follow the steps to re-run, after ticking "Enable debug
 logging".
 
 In order to to connect, install Tailscale and SSH, login to Tailscale and
-locate the following section of the job output to determine the SSH command to
-use:
+locate the following section of the `Tailscale SSH debug` step output to
+determine the SSH command to use:
 
 ```
 Warning: SSH Debugging Enabled

--- a/tailscale-ssh/README.md
+++ b/tailscale-ssh/README.md
@@ -13,3 +13,8 @@ steps:
 ```
 
 For optional input parameters, see [action.yml](action.yml).
+
+To ensure that the SSH session is as useful as possible for debugging, this
+step should be placed immediately before the build.  This avoids scenarios
+where cleanup from other post steps removes things that may be useful for
+debugging, such as logging out of docker container registries.


### PR DESCRIPTION
Move the `Tailscale SSH debug` step immediately before the build to retain as much of the build environment as possible during debugging.  This includes docker being logged into ECR where previously, docker was logged out while debugging over SSH may still be taking place.

The original rationale was to setup SSH as early as possible to let people connect early.  However many of the setup jobs such as `aws-actions/configure-aws-credential`, `aws-actions/amazon-ecr-login` and `docker/setup-buildx-action` also have a post-step to stop/remove anything they added.  As the post-steps run in reverse order, the SSH job originally ran after everything had been torn down, which made debugging harder.  This updated moves the SSH step so that the post-step to wait for sessions runs before any of the others, meaning that the environment is as close to the build as possible with docker still logged into ECR etc.