### PR TITLE
PT-3993 Decrease session wait time

### DIFF
--- a/tailscale-ssh/action.yml
+++ b/tailscale-ssh/action.yml
@@ -7,7 +7,7 @@ inputs:
   ssh-wait-minutes:
     required: false
     type: number
-    default: 10
+    default: 1
     description: 'Number of minutes to wait for SSH connections at end of job'
   ts-oauth-client-id:
     description: 'Tailscale OAuth Client ID'


### PR DESCRIPTION
Many of our CI jobs run Tailscale SSH when debug logging is enabled and wait for users to connect before allowing the job to complete so that there is time to copy+paste the SSH command.  However the default of 10 minutes is impractical and means that you have to leave the runner spinning that long to get a successful run without cancelling (when debug logging is enabled).

The session wait should be reduced to 1 minute.